### PR TITLE
Make copy of image before aligning blocks

### DIFF
--- a/luma/led_matrix/device.py
+++ b/luma/led_matrix/device.py
@@ -81,6 +81,7 @@ class max7219(device):
         image = super(max7219, self).preprocess(image)
 
         if self._block_orientation == "vertical":
+            image = image.copy()
             for y in range(0, self._h, 8):
                 for x in range(0, self._w, 8):
                     box = (x, y, x + 8, y + 8)


### PR DESCRIPTION
There is an edge case where end-user code is supplying an image rather
than one being created directly with the canvas context; we shouldn’t
be mutating their image - make a copy of it instead.