### PR TITLE
Huge performance improvements for cascaded MAX7219 devices

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ ChangeLog
 +------------+------------------------------------------------------------------------+------------+
 | Version    | Description                                                            | Date       |
 +============+========================================================================+============+
-| *Upcoming* | *TBC*                                                                  |            |
+| *Upcoming* | * Huge performance improvements for cascaded MAX7219 devices           |            |
 +------------+------------------------------------------------------------------------+------------+
 | **0.5.2**  | * Add apostrophe representation to seven-segment display               | 2017/02/19 |
 |            | * Deprecate ``luma.led_matrix.legacy`` (moved to ``luma.core.legacy``) |            |


### PR DESCRIPTION
Pillow's getPixel() call is quite slow; get the image data up front
instead + some aggressive loop optimizations

PiZero with 4 cascaded MAX7219's:
* before = 89 FPS
* after = 460 FPS