### PR TITLE
Support arbitrary MxN cascaded MAX7219 devices

### DIFF
--- a/doc/python-usage.rst
+++ b/doc/python-usage.rst
@@ -160,9 +160,9 @@ horizontally, running left to right.
 
 Alternatively, the device configuration may configured with ``width=W`` and
 ``height=H``. These dimensions denote the number of LEDs in the all the
-daisychained devices. The width *must* be a multiple of 8, and currently,
-height *must* only be 8. This has future scope for arranging in blocks in, say
-3x3 or 5x2 matrices.
+daisychained devices. The width and height *must* both be multiples of 8: this
+has scope for arranging in blocks in, say 3x3 or 5x2 matrices (24x24 or 40x16
+pixels, respectively).
 
 .. code:: python
 

--- a/luma/led_matrix/device.py
+++ b/luma/led_matrix/device.py
@@ -54,17 +54,17 @@ class max7219(device):
 
         self.capabilities(width, height, rotate)
 
-        # Currently only allow a strip of matrices
-        # TODO: Future enhancement - allow blocks, e.g 40x16 (5x2 blocks)
-        if width % 8 != 0 or height != 8:
+        if width <= 0 or width % 8 != 0 or height <= 0 or height % 8 != 0:
             raise luma.core.error.DeviceDisplayModeError(
                 "Unsupported display mode: {0} x {1}".format(width, height))
 
-        self.cascaded = cascaded or width // 8
+        self.cascaded = cascaded or (width * height) // 64
         assert(block_orientation in ["horizontal", "vertical"])
         self._block_orientation = block_orientation
-        self._offsets = list(range((self.cascaded - 1) * 8, -8, -8))
-        self._rows = list(range(self._h))
+        self._offsets = [(y * self._w) + x
+                         for y in range(self._h - 8, -8, -8)
+                         for x in range(self._w - 8, -8, -8)]
+        self._rows = list(range(8))
 
         self.data([self._const.SCANLIMIT, 7] * self.cascaded)
         self.data([self._const.DECODEMODE, 0] * self.cascaded)

--- a/tests/test_max7219.py
+++ b/tests/test_max7219.py
@@ -95,7 +95,7 @@ def test_contrast():
     serial.data.assert_called_once_with([10, 6] * 6)
 
 
-def test_display():
+def test_display_16x8():
     device = max7219(serial, cascaded=2)
     serial.reset_mock()
 
@@ -111,6 +111,25 @@ def test_display():
         call([6, 0x81, 6, 0x81]),
         call([7, 0x81, 7, 0x81]),
         call([8, 0xFF, 8, 0x81])
+    ])
+
+
+def test_display_16x16():
+    device = max7219(serial, width=16, height=16)
+    serial.reset_mock()
+
+    with canvas(device) as draw:
+        draw.rectangle(device.bounding_box, outline="white")
+
+    serial.data.assert_has_calls([
+        call([1, 0x80, 1, 0xFF, 1, 0x01, 1, 0xFF]),
+        call([2, 0x80, 2, 0x80, 2, 0x01, 2, 0x01]),
+        call([3, 0x80, 3, 0x80, 3, 0x01, 3, 0x01]),
+        call([4, 0x80, 4, 0x80, 4, 0x01, 4, 0x01]),
+        call([5, 0x80, 5, 0x80, 5, 0x01, 5, 0x01]),
+        call([6, 0x80, 6, 0x80, 6, 0x01, 6, 0x01]),
+        call([7, 0x80, 7, 0x80, 7, 0x01, 7, 0x01]),
+        call([8, 0xFF, 8, 0x80, 8, 0xFF, 8, 0x01])
     ])
 
 


### PR DESCRIPTION
Previously, we only supported Mx8 (i.e a single row of daisy-chained devices), now banks of devices can be stacked together.

#### TODO:
* add/update documentation
* tests