### PR TITLE
Changed block_orientation valid parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ ChangeLog
 +------------+------------------------------------------------------------------------+------------+
 | Version    | Description                                                            | Date       |
 +============+========================================================================+============+
+| *Upcoming* | * Change MAX7219's block_orientation to support ±90° angle correction  |            |
+|            | * Deprecate "vertical" and "horizontal" block_orientation              |            |
++------------+------------------------------------------------------------------------+------------+
 | **0.7.0**  | * **BREAKING CHANGE:** Move sevensegment class to                      | 2017/03/04 |
 |            |   ``luma.led_matrix.virtual`` package                                  |            |
 |            | * Documentation updates & corrections                                  |            |

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -126,7 +126,7 @@ matrices::
 
     $ python examples/matrix_demo.py -h
     usage: matrix_demo.py [-h] [--cascaded CASCADED]
-                          [--block-orientation {horizontal,vertical}]
+                          [--block-orientation {0, 90, -90}]
 
     matrix_demo arguments
 
@@ -134,9 +134,9 @@ matrices::
     -h, --help            show this help message and exit
     --cascaded CASCADED, -n CASCADED
                           Number of cascaded MAX7219 LED matrices (default: 1)
-    --block-orientation {horizontal,vertical}
+    --block-orientation {0, 90, -90}
                           Corrects block orientation when wired vertically
-                          (default: horizontal)
+                          (default: 0)
 
 Similarly, there is a basic demo of the capabilities of the
 :py:class:`luma.led_matrix.virtual.sevensegment` wrapper::

--- a/doc/python-usage.rst
+++ b/doc/python-usage.rst
@@ -179,7 +179,7 @@ below,
    from luma.led_matrix.device import max7219
    from luma.core.legacy.font import proportional, LCD_FONT
 
-   serial = spi(port=0, device=0, gpio=noop(), block_orientation="vertical")
+   serial = spi(port=0, device=0, gpio=noop(), block_orientation=-90)
    device = max7219(serial, width=32, height=24)
 
    with canvas(device) as draw:
@@ -202,8 +202,9 @@ out-of-phase such that horizontal scrolling appears as below:
 .. image:: images/block_reorientation.gif
    :alt: block alignment
 
-This can be rectified by initializing the :py:class:`~luma.led_matrix.device.max7219` 
-device with a parameter of :py:attr:`block_orientation="vertical"`:
+This can be rectified by initializing the :py:class:`~luma.led_matrix.device.max7219`
+device with a parameter of :py:attr:`block_orientation=-90` (or +90, if your device is
+aligned the other way):
 
 .. code:: python
 
@@ -212,7 +213,7 @@ device with a parameter of :py:attr:`block_orientation="vertical"`:
    from luma.led_matrix.device import max7219
 
    serial = spi(port=0, device=0, gpio=noop())
-   device = max7219(serial, cascaded=4, block_orientation="vertical")
+   device = max7219(serial, cascaded=4, block_orientation=-90)
 
 Every time a display render is subsequenly requested, the underlying image
 representation is corrected to reverse the 90° phase shift.

--- a/examples/box_demo.py
+++ b/examples/box_demo.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
 
     parser.add_argument('--width', type=int, default=8, help='Width')
     parser.add_argument('--height', type=int, default=8, help='height')
-    parser.add_argument('--block-orientation', type=str, default='vertical', choices=['horizontal', 'vertical'], help='Corrects block orientation when wired vertically')
+    parser.add_argument('--block-orientation', type=int, default=-90, choices=[0, 90, -90], help='Corrects block orientation when wired vertically')
     parser.add_argument('--rotate', type=int, default=0, choices=[0, 1, 2, 3], help='Rotation factor')
 
     args = parser.parse_args()

--- a/examples/matrix_demo.py
+++ b/examples/matrix_demo.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser.add_argument('--cascaded', '-n', type=int, default=1, help='Number of cascaded MAX7219 LED matrices')
-    parser.add_argument('--block-orientation', type=str, default='horizontal', choices=['horizontal', 'vertical'], help='Corrects block orientation when wired vertically')
+    parser.add_argument('--block-orientation', type=str, default=0, choices=[0, 90, -90], help='Corrects block orientation when wired vertically')
 
     args = parser.parse_args()
 

--- a/luma/led_matrix/legacy.py
+++ b/luma/led_matrix/legacy.py
@@ -8,7 +8,8 @@ from luma.core.legacy.font import proportional, CP437_FONT, SINCLAIR_FONT, LCD_F
 
 
 # trigger DeprecationWarning
-deprecation_msg = ("WARNING! 'luma.led_matrix.legacy' is now deprecated and will be removed in "
-      "v1.0.0. Please use the equivalent functionality from "
-      "'luma.core.legacy' and 'luma.core.legacy.font'.")
+deprecation_msg = (
+    "WARNING! 'luma.led_matrix.legacy' is now deprecated and will be removed in "
+    "v1.0.0. Please use the equivalent functionality from "
+    "'luma.core.legacy' and 'luma.core.legacy.font'.")
 deprecation(deprecation_msg)


### PR DESCRIPTION
Used to take “horizontal” or “vertical”, now additionally allows 0, 90, -90.
The strings are marked as deprecated and are no longer documented, but
are still supported up until the next major version.

Fixes #93