### PR TITLE
Fix problems with DMA channels on Raspberry Pi 3

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -19,3 +19,4 @@ Contributors
 * Brice Parent (@agripo)
 * Thomas De Keulenaer (@twdkeule)
 * Tero Korpela (@terokorp)
+* Qinkang Huang (@pokebox)

--- a/luma/led_matrix/device.py
+++ b/luma/led_matrix/device.py
@@ -219,7 +219,7 @@ class ws2812(device):
 
         pin = 18
         channel = 0
-        dma = 5
+        dma = 10
         freq_hz = 800000
         brightness = 255
         strip_type = ws.WS2811_STRIP_GRB


### PR DESCRIPTION
For example, using DMA channel 5 will cause filesystem corruption on the Raspberry Pi 3 Model B.
The default DMA channel (10) should be safe for the Raspberry Pi 3 Model B, but this may change in future software releases.

fixes #141 