### PR TITLE
Option to skip unknown characters

### DIFF
--- a/luma/led_matrix/device.py
+++ b/luma/led_matrix/device.py
@@ -509,30 +509,24 @@ class neosegment(sevensegment):
                         draw.point((x, y), fill=color[x])
                     byte >>= 1
 
-    def segment_mapper(self, text, notfound="_"):
-        try:
-            iterator = regular(text, notfound)
-            while True:
-                char = next(iterator)
+    def segment_mapper(self, text, notfound=None):
+        for char in regular(text, notfound):
 
-                # Convert from std MAX7219 segment mappings
-                a = char >> 6 & 0x01
-                b = char >> 5 & 0x01
-                c = char >> 4 & 0x01
-                d = char >> 3 & 0x01
-                e = char >> 2 & 0x01
-                f = char >> 1 & 0x01
-                g = char >> 0 & 0x01
+            # Convert from std MAX7219 segment mappings
+            a = char >> 6 & 0x01
+            b = char >> 5 & 0x01
+            c = char >> 4 & 0x01
+            d = char >> 3 & 0x01
+            e = char >> 2 & 0x01
+            f = char >> 1 & 0x01
+            g = char >> 0 & 0x01
 
-                # To NeoSegment positions
-                yield \
-                    b << 6 | \
-                    a << 5 | \
-                    f << 4 | \
-                    g << 3 | \
-                    c << 2 | \
-                    d << 1 | \
-                    e << 0
-
-        except StopIteration:
-            pass
+            # To NeoSegment positions
+            yield \
+                b << 6 | \
+                a << 5 | \
+                f << 4 | \
+                g << 3 | \
+                c << 2 | \
+                d << 1 | \
+                e << 0

--- a/luma/led_matrix/device.py
+++ b/luma/led_matrix/device.py
@@ -509,7 +509,7 @@ class neosegment(sevensegment):
                         draw.point((x, y), fill=color[x])
                     byte >>= 1
 
-    def segment_mapper(self, text, notfound=None):
+    def segment_mapper(self, text, notfound="_"):
         for char in regular(text, notfound):
 
             # Convert from std MAX7219 segment mappings

--- a/luma/led_matrix/segment_mapper.py
+++ b/luma/led_matrix/segment_mapper.py
@@ -76,34 +76,29 @@ _DIGITS = {
 }
 
 
-def regular(text, notfound="_"):
-    try:
-        undefined = _DIGITS[notfound]
-        iterator = iter(text)
-        while True:
-            char = next(iterator)
-            yield _DIGITS.get(char, undefined)
-    except StopIteration:
-        pass
+def regular(text, notfound=None):
+    undefined = _DIGITS[notfound] if notfound is not None else None
+    for char in iter(text):
+        d = _DIGITS.get(char, undefined)
+        if d is not None:
+            yield d
 
 
-def dot_muncher(text, notfound="_"):
+def dot_muncher(text, notfound=None):
     if not text:
         return
 
-    undefined = _DIGITS[notfound]
-    iterator = iter(text)
-    last = _DIGITS.get(next(iterator), undefined)
-    try:
-        while True:
-            curr = _DIGITS.get(next(iterator), undefined)
+    undefined = _DIGITS[notfound] if notfound is not None else None
+    last = None
+    for char in iter(text):
+        curr = _DIGITS.get(char, undefined)
 
-            if curr == 0x80:
-                yield curr | last
-            elif last != 0x80:
-                yield last
-
-            last = curr
-    except StopIteration:
-        if last != 0x80:
+        if curr == 0x80:
+            yield curr | (last or 0)
+        elif last != 0x80 and last is not None:
             yield last
+
+        last = curr
+
+    if curr != 0x80 and curr is not None:
+        yield curr

--- a/luma/led_matrix/segment_mapper.py
+++ b/luma/led_matrix/segment_mapper.py
@@ -79,9 +79,9 @@ _DIGITS = {
 def regular(text, notfound="_"):
     undefined = _DIGITS[notfound] if notfound is not None else None
     for char in iter(text):
-        d = _DIGITS.get(char, undefined)
-        if d is not None:
-            yield d
+        digit = _DIGITS.get(char, undefined)
+        if digit is not None:
+            yield digit
 
 
 def dot_muncher(text, notfound="_"):

--- a/luma/led_matrix/segment_mapper.py
+++ b/luma/led_matrix/segment_mapper.py
@@ -76,7 +76,7 @@ _DIGITS = {
 }
 
 
-def regular(text, notfound=None):
+def regular(text, notfound="_"):
     undefined = _DIGITS[notfound] if notfound is not None else None
     for char in iter(text):
         d = _DIGITS.get(char, undefined)
@@ -84,7 +84,7 @@ def regular(text, notfound=None):
             yield d
 
 
-def dot_muncher(text, notfound=None):
+def dot_muncher(text, notfound="_"):
     if not text:
         return
 

--- a/tests/test_segment_mapper.py
+++ b/tests/test_segment_mapper.py
@@ -40,6 +40,12 @@ def test_dot_muncher_empty_buf():
     assert list(results) == []
 
 
+def test_dot_muncher_skips_unknown():
+    buf = mutable_string("B&B")
+    results = dot_muncher(buf)
+    assert list(results) == [0x7f, 0x7f]
+
+
 def test_regular_without_dots():
     buf = mutable_string("Hello world")
     results = regular(buf)
@@ -62,6 +68,12 @@ def test_regular_empty_buf():
     buf = mutable_string("")
     results = regular(buf)
     assert list(results) == []
+
+
+def test_regular_skips_unknown():
+    buf = mutable_string("B&B")
+    results = regular(buf)
+    assert list(results) == [0x7f, 0x7f]
 
 
 def test_degrees_unicode():

--- a/tests/test_segment_mapper.py
+++ b/tests/test_segment_mapper.py
@@ -10,7 +10,7 @@ from luma.led_matrix.segment_mapper import dot_muncher, regular
 
 def test_dot_muncher_without_dots():
     buf = mutable_string("Hello world")
-    results = dot_muncher(buf)
+    results = dot_muncher(buf, notfound='_')
     assert list(results) == [0x37, 0x6f, 0x06, 0x06, 0x1d, 0x00, 0x08, 0x1d, 0x05, 0x06, 0x3d]
 
 
@@ -28,10 +28,22 @@ def test_dot_muncher_with_dot_at_end():
     assert list(results) == [0x00, 0x00, 0x5b, 0x6d, 0x5b, 0x7b, 0x6d, 0x7e | 0x80]
 
 
+def test_dot_muncher_with_dot_at_start():
+    buf = mutable_string(".PDF")
+    results = dot_muncher(buf)
+    assert list(results) == [0x80, 0x67, 0x7e, 0x47]
+
+
 def test_dot_muncher_with_multiple_dot():
     buf = mutable_string("127.0.0.1")
     results = dot_muncher(buf)
     assert list(results) == [0x30, 0x6d, 0x70 | 0x80, 0x7e | 0x80, 0x7e | 0x80, 0x30]
+
+
+def test_dot_muncher_with_consecutive_dot():
+    buf = mutable_string("No...")
+    results = dot_muncher(buf)
+    assert list(results) == [0x76, 0x1d | 0x80, 0x80, 0x80]
 
 
 def test_dot_muncher_empty_buf():
@@ -46,9 +58,15 @@ def test_dot_muncher_skips_unknown():
     assert list(results) == [0x7f, 0x7f]
 
 
+def test_dot_muncher_with_notfound():
+    buf = mutable_string("B&B")
+    results = dot_muncher(buf, notfound='_')
+    assert list(results) == [0x7f, 0x08, 0x7f]
+
+
 def test_regular_without_dots():
     buf = mutable_string("Hello world")
-    results = regular(buf)
+    results = regular(buf, notfound='_')
     assert list(results) == [0x37, 0x6f, 0x06, 0x06, 0x1d, 0x00, 0x08, 0x1d, 0x05, 0x06, 0x3d]
 
 
@@ -74,6 +92,12 @@ def test_regular_skips_unknown():
     buf = mutable_string("B&B")
     results = regular(buf)
     assert list(results) == [0x7f, 0x7f]
+
+
+def test_regular_with_notfound():
+    buf = mutable_string("B&B")
+    results = regular(buf, notfound='_')
+    assert list(results) == [0x7f, 0x08, 0x7f]
 
 
 def test_degrees_unicode():

--- a/tests/test_segment_mapper.py
+++ b/tests/test_segment_mapper.py
@@ -54,7 +54,7 @@ def test_dot_muncher_empty_buf():
 
 def test_dot_muncher_skips_unknown():
     buf = mutable_string("B&B")
-    results = dot_muncher(buf)
+    results = dot_muncher(buf, notfound=None)
     assert list(results) == [0x7f, 0x7f]
 
 
@@ -90,7 +90,7 @@ def test_regular_empty_buf():
 
 def test_regular_skips_unknown():
     buf = mutable_string("B&B")
-    results = regular(buf)
+    results = regular(buf, notfound=None)
     assert list(results) == [0x7f, 0x7f]
 
 


### PR DESCRIPTION
It would be nice to have an option to skip unknown characters instead of replacing them with a default. This PR enables you to do that by setting `notfound=None`.

Especially if #178 is merged, then all standard alphanumeric characters will have some representation, and I think it would make sense to make it the default? Users can still get the old behaviour by setting `notfound='_'`.

While there, I also simplified the loops to use `for`/`in` instead of explicitly dealing with iterators, and fixed (what i think is) a bug, in that `dot_muncher` was ignoring any dot at the start of the string.

This PR would need a bit of tweaking if #178 is merged, but I preferred to base it on top of master for now so that the changes are clearer.