### PR TITLE
Add option controlling whether the 8x8 blocks are arranged in reverse order.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -25,3 +25,4 @@ Contributors
 * Petr Kracík (@petrkr)
 * Emlyn Corrin (@emlyn)
 * Bram Verboom (@bramverb)
+* Thanassis Tsiodras (@ttsiodras)

--- a/examples/matrix_demo.py
+++ b/examples/matrix_demo.py
@@ -15,10 +15,11 @@ from luma.core.legacy import text, show_message
 from luma.core.legacy.font import proportional, CP437_FONT, TINY_FONT, SINCLAIR_FONT, LCD_FONT
 
 
-def demo(n, block_orientation, rotate):
+def demo(n, block_orientation, rotate, inreverse):
     # create matrix device
     serial = spi(port=0, device=0, gpio=noop())
-    device = max7219(serial, cascaded=n or 1, block_orientation=block_orientation, rotate=rotate or 0)
+    device = max7219(serial, cascaded=n or 1, block_orientation=block_orientation,
+                     rotate=rotate or 0, blocks_arranged_in_reverse_order=inreverse)
     print("Created device")
 
     # start demo
@@ -113,10 +114,11 @@ if __name__ == "__main__":
     parser.add_argument('--cascaded', '-n', type=int, default=1, help='Number of cascaded MAX7219 LED matrices')
     parser.add_argument('--block-orientation', type=int, default=0, choices=[0, 90, -90], help='Corrects block orientation when wired vertically')
     parser.add_argument('--rotate', type=int, default=0, choices=[0, 1, 2, 3], help='Rotate display 0=0°, 1=90°, 2=180°, 3=270°')
+    parser.add_argument('--reverse-order', type=bool, default=False, help='Set to true if blocks are in reverse order')
 
     args = parser.parse_args()
 
     try:
-        demo(args.cascaded, args.block_orientation, args.rotate)
+        demo(args.cascaded, args.block_orientation, args.rotate, args.reverse_order)
     except KeyboardInterrupt:
         pass

--- a/examples/silly_clock.py
+++ b/examples/silly_clock.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python2
+import time
+from datetime import datetime
+
+from luma.led_matrix.device import max7219
+from luma.core.interface.serial import spi, noop
+from luma.core.render import canvas
+from luma.core.legacy import text, show_message
+from luma.core.legacy.font import proportional, CP437_FONT, TINY_FONT
+
+
+def minute_change(device):
+    '''When we reach a minute change, animate it.'''
+    hours = datetime.now().strftime('%H')
+    minutes = datetime.now().strftime('%M')
+
+    def helper(current_y):
+        with canvas(device) as draw:
+            text(draw, (0, 1), hours, fill="white", font=proportional(CP437_FONT))
+            text(draw, (15, 1), ":", fill="white", font=proportional(TINY_FONT))
+            text(draw, (17, current_y), minutes, fill="white", font=proportional(CP437_FONT))
+        time.sleep(0.1)
+    for current_y in range(1, 9):
+        helper(current_y)
+    minutes = datetime.now().strftime('%M')
+    for current_y in range(9, 1, -1):
+        helper(current_y)
+
+
+def animation(device, from_y, to_y):
+    '''Animate the whole thing, moving it into/out of the abyss.'''
+    hourstime = datetime.now().strftime('%H')
+    mintime = datetime.now().strftime('%M')
+    current_y = from_y
+    while current_y != to_y:
+        with canvas(device) as draw:
+            text(draw, (0, current_y), hourstime, fill="white", font=proportional(CP437_FONT))
+            text(draw, (15, current_y), ":", fill="white", font=proportional(TINY_FONT))
+            text(draw, (17, current_y), mintime, fill="white", font=proportional(CP437_FONT))
+        time.sleep(0.1)
+        current_y += 1 if to_y > from_y else -1
+
+
+def main():
+    # Setup for Banggood version of 4 x 8x8 LED Matrix (https://bit.ly/2Gywazb)
+    serial = spi(port=0, device=0, gpio=noop())
+    device = max7219(serial, cascaded=4, block_orientation=-90, blocks_arranged_in_reverse_order=True)
+    device.contrast(16)
+
+    # The time ascends from the abyss...
+    animation(device, 8, 1)
+
+    toggle = False  # Toggle the second indicator every second
+    while True:
+        toggle = not toggle
+        sec = datetime.now().second
+        if sec == 59:
+            # When we change minutes, animate the minute change
+            minute_change(device)
+        elif sec == 30:
+            # Half-way through each minute, display the complete date/time,
+            # animating the time display into and out of the abyss.
+            full_msg = time.ctime()
+            animation(device, 1, 8)
+            show_message(device, full_msg, fill="white", font=proportional(CP437_FONT))
+            animation(device, 8, 1)
+        else:
+            # Do the following twice a second (so the seconds' indicator blips).
+            # I'd optimize if I had to - but what's the point?
+            # Even my Raspberry PI2 can do this at 4% of a single one of the 4 cores!
+            hours = datetime.now().strftime('%H')
+            minutes = datetime.now().strftime('%M')
+            with canvas(device) as draw:
+                text(draw, (0, 1), hours, fill="white", font=proportional(CP437_FONT))
+                text(draw, (15, 1), ":" if toggle else " ", fill="white", font=proportional(TINY_FONT))
+                text(draw, (17, 1), minutes, fill="white", font=proportional(CP437_FONT))
+            time.sleep(0.5)
+
+
+if __name__ == "__main__":
+    main()

--- a/luma/led_matrix/device.py
+++ b/luma/led_matrix/device.py
@@ -55,7 +55,7 @@ class max7219(device):
     brightness and other settings.
     """
     def __init__(self, serial_interface=None, width=8, height=8, cascaded=None, rotate=0,
-                 block_orientation=0, **kwargs):
+                 block_orientation=0, blocks_arranged_in_reverse_order=False, **kwargs):
         super(max7219, self).__init__(luma.led_matrix.const.max7219, serial_interface)
 
         # Derive (override) the width and height if a cascaded param supplied
@@ -63,6 +63,7 @@ class max7219(device):
             width = cascaded * 8
             height = 8
 
+        self.blocks_arranged_in_reverse_order = blocks_arranged_in_reverse_order
         self.capabilities(width, height, rotate)
         self.segment_mapper = dot_muncher
 
@@ -102,6 +103,12 @@ class max7219(device):
                     box = (x, y, x + 8, y + 8)
                     rotated_block = image.crop(box).rotate(self._correction_angle)
                     image.paste(rotated_block, box)
+        if self.blocks_arranged_in_reverse_order:
+            old_image = image.copy()
+            for y in range(8):
+                for x in range(8):
+                    for i in range(self.cascaded):
+                        image.putpixel((24-i*8 + x, y), old_image.getpixel((i*8 + x,y)))
 
         return image
 

--- a/luma/led_matrix/device.py
+++ b/luma/led_matrix/device.py
@@ -108,7 +108,7 @@ class max7219(device):
             for y in range(8):
                 for x in range(8):
                     for i in range(self.cascaded):
-                        image.putpixel((24 - i * 8 + x, y), old_image.getpixel((i * 8 + x, y)))
+                        image.putpixel((8 * (self.cascaded - 1) - i * 8 + x, y), old_image.getpixel((i * 8 + x, y)))
 
         return image
 

--- a/luma/led_matrix/device.py
+++ b/luma/led_matrix/device.py
@@ -108,7 +108,7 @@ class max7219(device):
             for y in range(8):
                 for x in range(8):
                     for i in range(self.cascaded):
-                        image.putpixel((24-i*8 + x, y), old_image.getpixel((i*8 + x,y)))
+                        image.putpixel((24 - i * 8 + x, y), old_image.getpixel((i * 8 + x, y)))
 
         return image
 

--- a/tests/test_max7219.py
+++ b/tests/test_max7219.py
@@ -17,6 +17,11 @@ def test_init_cascaded():
     assert device.height == 8
 
 
+def test_init_reversed():
+    device = max7219(serial, cascaded=4, blocks_arranged_in_reverse_order=True)
+    assert device.blocks_arranged_in_reverse_order == True
+
+
 def test_init_8x8():
     device = max7219(serial)
     assert device.cascaded == 1

--- a/tests/test_max7219.py
+++ b/tests/test_max7219.py
@@ -201,6 +201,25 @@ def test_block_realignment_plus180():
     ])
 
 
+def test_reversed_max7219():
+    device = max7219(serial, cascaded=4, blocks_arranged_in_reverse_order=True)
+    serial.reset_mock()
+
+    with canvas(device) as draw:
+        draw.rectangle((0, 0, 15, 3), outline="white")
+
+    serial.data.assert_has_calls([
+        call([1, 15, 1, 9, 1, 0, 1, 0]),
+        call([2, 9, 2, 9, 2, 0, 2, 0]),
+        call([3, 9, 3, 9, 3, 0, 3, 0]),
+        call([4, 9, 4, 9, 4, 0, 4, 0]),
+        call([5, 9, 5, 9, 5, 0, 5, 0]),
+        call([6, 9, 6, 9, 6, 0, 6, 0]),
+        call([7, 9, 7, 9, 7, 0, 7, 0]),
+        call([8, 9, 8, 15, 8, 0, 8, 0])
+    ])
+
+
 def test_unknown_block_orientation():
     with pytest.raises(AssertionError):
         max7219(serial, cascaded=2, block_orientation="sausages")

--- a/tests/test_max7219.py
+++ b/tests/test_max7219.py
@@ -19,7 +19,7 @@ def test_init_cascaded():
 
 def test_init_reversed():
     device = max7219(serial, cascaded=4, blocks_arranged_in_reverse_order=True)
-    assert device.blocks_arranged_in_reverse_order == True
+    assert device.blocks_arranged_in_reverse_order is True
 
 
 def test_init_8x8():


### PR DESCRIPTION
The Banggood version that I bought [from here](https://bit.ly/2Gywazb)
had the order of the 4 blocks in the reverse direction; no combination
of block-orientation and rotate could fix this, so I made this patch;
and also updated the matrix_demo - which can now be run as follows
for this board:

    python2 ./matrix_demo.py -n 4 --block-orientation -90 --reverse-order True