### PR TITLE
No reason to limit this to Python2.

### DIFF
--- a/examples/silly_clock.py
+++ b/examples/silly_clock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import time
 from datetime import datetime
 


### PR DESCRIPTION
As requested by @thijstriemstra , made a quick PR to stop limiting the silly_clock to Python 2.