### PR TITLE
Correct WS2812 and APA102 brand names in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,10 +28,10 @@ Luma.LED_Matrix
 .. image:: https://img.shields.io/maintenance/yes/2020.svg?maxAge=2592000
 
 Python 3 library interfacing LED matrix displays with the MAX7219 driver (using
-SPI) and WS2812 & APA102 NeoPixels (inc Pimoroni Unicorn pHat/Hat and Unicorn
-Hat HD) on the Raspberry Pi and other Linux-based single board computers - it
-provides a `Pillow <https://pillow.readthedocs.io/>`_-compatible drawing canvas,
-and other functionality to support:
+SPI), WS2812 (NeoPixels, inc Pimoroni Unicorn pHat/Hat and Unicorn Hat HD) and
+APA102 (DotStar) on the Raspberry Pi and other Linux-based single board computers
+- it provides a `Pillow <https://pillow.readthedocs.io/>`_-compatible drawing
+canvas, and other functionality to support:
 
 * multiple cascaded devices
 * LED matrix, seven-segment and NeoPixel variants


### PR DESCRIPTION
WS281X pixels are NeoPixels
APA102 pixels are DotStar

These are both Adafruit rebrands of the WS2812 and APA102 respectively, and are additionally trademarked.

I've corrected APA102 to DotStar here, since this will be the name by which many people know these pixels.

It might be prudent to format these compatible device lists as lists, since it's painful grappling with the line-length and word-wrap every time a new device is added and it totally breaks the GitHub change detection.