### PR TITLE
Change install command to specify use of Python 3

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -112,7 +112,7 @@ Install the dependencies for library first with::
 Proceed to install latest version of the luma.led_matrix library directly from
 `PyPI <https://pypi.python.org/pypi?:action=display&name=luma.led_matrix>`_::
 
-  $ sudo -H pip install --upgrade luma.led_matrix
+  $ sudo python3 -m pip install --upgrade luma.led_matrix
 
 Examples
 ^^^^^^^^


### PR DESCRIPTION
I had to change the install command to force use of Python 3 on my Raspberry Pi, otherwise it tried to install the plugin against Python 2.7. I guess it can't hurt to specify it for all users. If not, feel free to reject this pr. Thanks for your work!